### PR TITLE
Add compatability with seblod CCK

### DIFF
--- a/autoreadmore.php
+++ b/autoreadmore.php
@@ -242,6 +242,13 @@ else
 			if ($this->paramGet('Ignore_Existing_Read_More') && isset($article->introtext) && isset($article->fulltext))
 			{
 				$text = $article->introtext . PHP_EOL . $article->fulltext;
+				if (file_exists(JPATH_PLUGINS . DS ."content/cck")) { //check if Seblod is installed
+				    $text = preg_replace( '/::cck::(\d+)::\/cck::/', '', $text ) ; //remove the ::cck:: tags
+				    $text = preg_replace( '/::introtext::/', '', $text ) ; //remove the ::introtext:: tags, keep content
+				    $text = preg_replace( '/::\/introtext::/', '', $text ) ; //remove the ::introtext:: tags, keep content
+				    $text = preg_replace( '/::fulltext::/', '', $text ) ; //remove the ::fulltext:: tags, keep content
+				    $text = preg_replace( '/::\/fulltext::/', '', $text ) ; //remove the ::fulltext:: tags, keep content
+				} 
 				$this->fulltext_loaded = true;
 			}
 			elseif ($this->paramGet('Ignore_Existing_Read_More') && isset($article->readmore) && $article->readmore > 0 )


### PR DESCRIPTION
There is a 'conflict' between readmore and seblod's cck.  seblod inserts some info in the introtext which allow it to link its own content.  These appear as ::cck::99::/cck:: and then the intro and full text is normally moved into full text and split using ::introtext::Some text::/introtext:: and ::fulltext::More text::/fulltext::

The changes will check if seblod is installed and if it is will remove the cck line and then strip off the introtext and fulltext tags.